### PR TITLE
fix(prefab): update ActiveButtonIndex when group button changes

### DIFF
--- a/Runtime/Prefabs/Interactions.SpatialButton.Group.prefab
+++ b/Runtime/Prefabs/Interactions.SpatialButton.Group.prefab
@@ -153,7 +153,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1be29dcf3d803d1498310343dbc8fada, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  initialActiveButtonIndex: -1
+  activeButtonIndex: -1
   buttonList: {fileID: 6279387543444412096}
   dispatcher: {fileID: 6279387542914970316}
 --- !u!114 &6279387542914970316
@@ -242,12 +242,34 @@ MonoBehaviour:
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6279387542914970315}
+        m_MethodName: SubscribeButtonActivated
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6279387542914970315}
+        m_MethodName: UnsubscribeButtonActivated
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:

--- a/Runtime/SharedResources/Scripts/SpatialButtonGroupManager.cs
+++ b/Runtime/SharedResources/Scripts/SpatialButtonGroupManager.cs
@@ -7,6 +7,7 @@
     using UnityEngine;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Collection.List;
+    using Zinnia.Data.Type;
     using Zinnia.Extension;
 
     /// <summary>
@@ -42,16 +43,19 @@
         /// The cached value of the <see cref="ActiveButtonIndex"/> before it is changed.
         /// </summary>
         protected int cachedIndex;
+        /// <summary>
+        /// Whether to ignore processing changes when the <see cref="ActiveButtonIndex"/> value changes.
+        /// </summary>
+        protected bool ignoreActiveButtonIndexChanges;
 
         /// <summary>
         /// Populates the list of valid group buttons.
         /// </summary>
         public virtual void PopulateValidButtonList()
         {
-            ButtonList.Clear();
             foreach (SpatialButtonFacade button in gameObject.GetComponentsInChildren<SpatialButtonFacade>())
             {
-                ButtonList.Add(button.Configuration.SpatialTargetFacade.gameObject);
+                ButtonList.RunWhenActiveAndEnabled(() => ButtonList.AddUnique(button.Configuration.SpatialTargetFacade.gameObject));
                 button.Configuration.SpatialTargetDispatcher = Dispatcher;
             }
         }
@@ -75,10 +79,47 @@
             }
         }
 
+        /// <summary>
+        /// Subscribes to the <see cref="SpatialTargetFacade.Activated"/> event.
+        /// </summary>
+        /// <param name="obj">The object containing the <see cref="SpatialTargetFacade"/>.</param>
+        public virtual void SubscribeButtonActivated(Object obj)
+        {
+            SpatialTargetFacade spatialTarget = (obj as GameObject).GetComponent<SpatialTargetFacade>();
+            spatialTarget.Activated.AddListener(SetActiveButtonIndexWhenButtonActivated);
+        }
+
+        /// <summary>
+        /// Unsubscribes to the <see cref="SpatialTargetFacade.Activated"/> event.
+        /// </summary>
+        /// <param name="obj">The object containing the <see cref="SpatialTargetFacade"/>.</param>
+        public virtual void UnsubscribeButtonActivated(Object obj)
+        {
+            SpatialTargetFacade spatialTarget = (obj as GameObject).GetComponent<SpatialTargetFacade>();
+            spatialTarget.Activated.RemoveListener(SetActiveButtonIndexWhenButtonActivated);
+        }
+
         protected virtual void OnEnable()
         {
             PopulateValidButtonList();
             ActivateButtonAtIndex(ActiveButtonIndex);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ActiveButtonIndex"/> when a button is activate.
+        /// </summary>
+        /// <param name="data">The data to retrieve the button being activated.</param>
+        protected virtual void SetActiveButtonIndexWhenButtonActivated(SurfaceData data)
+        {
+            SpatialTargetFacade spatialTarget = data.Transform.gameObject.TryGetComponent<SpatialTargetFacade>(false, true);
+            if (spatialTarget == null)
+            {
+                return;
+            }
+
+            ignoreActiveButtonIndexChanges = true;
+            ActiveButtonIndex = ButtonList.IndexOf(spatialTarget.gameObject);
+            ignoreActiveButtonIndexChanges = false;
         }
 
         /// <summary>
@@ -112,6 +153,11 @@
         [CalledAfterChangeOf(nameof(ActiveButtonIndex))]
         protected virtual void OnAfterActiveButtonIndexChange()
         {
+            if (ignoreActiveButtonIndexChanges)
+            {
+                return;
+            }
+
             if (ActiveButtonIndex == -1)
             {
                 SpatialButtonFacade spatialButton = GetSpatialButtonAtIndex(cachedIndex);


### PR DESCRIPTION
The ActiveButtonIndex property will now correctly reflect the actual
selected button and not only used for the initial set.