### PR TITLE
fix(prefabs): allow option group buttons to be touched on and off

### DIFF
--- a/Runtime/Prefabs/Interactions.SpatialButton.OptionButton.prefab
+++ b/Runtime/Prefabs/Interactions.SpatialButton.OptionButton.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     - target: {fileID: 3991973942380455354, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
       propertyPath: m_Name
-      value: Interactions.SpatialButton.GroupButton
+      value: Interactions.SpatialButton.OptionButton
       objectReference: {fileID: 0}
     - target: {fileID: 3991973942380455356, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
@@ -87,6 +87,16 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1712782886781501726, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: Extracted.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1639191951141537450}
+    - target: {fileID: 1712782886781501726, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: Extracted.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Select
+      objectReference: {fileID: 0}
     - target: {fileID: 4088187645122458557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
       propertyPath: m_Mesh
@@ -94,3 +104,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6c5e61ad8d2b39f4da6fc035d795d871, type: 3}
+--- !u!114 &1639191951141537450 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3991973940466226979, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    type: 3}
+  m_PrefabInstance: {fileID: 2439195365935911305}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27ae0e69cbf616a44bfb660995e29e77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Runtime/SharedResources/Scripts/SpatialButtonConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SpatialButtonConfigurator.cs
@@ -114,6 +114,7 @@
         {
             if (SpatialTargetDispatcher == null)
             {
+                SpatialTargetFacade.Configuration.TargetController.DoSelect(data);
                 return;
             }
 
@@ -123,12 +124,12 @@
         }
 
         /// <summary>
-        /// Selects the containing button with null data.
+        /// Selects the containing button.
         /// </summary>
-        public virtual void Select()
+        /// <param name="selectingObject">An optional <see cref="GameObject"/> that is selecting the button.</param>
+        public virtual void Select(GameObject selectingObject = null)
         {
-            SurfaceData data = new SurfaceData();
-            data.Transform = Facade.transform;
+            SurfaceData data = new SurfaceData(selectingObject != null ? selectingObject.transform : Facade.transform);
             Vector3 rayOrigin = new Vector3(Facade.transform.position.x, Facade.transform.position.y, Facade.transform.position.z - (Facade.transform.localScale.z * 0.501f));
             Physics.Raycast(rayOrigin, Facade.transform.forward, out RaycastHit hit);
             data.CollisionData = hit;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.tilia.indicators.spatialtargets.unity": "1.5.3",
+        "io.extendreality.tilia.indicators.spatialtargets.unity": "1.5.4",
         "com.unity.textmeshpro": "1.3.0"
     },
     "files": [


### PR DESCRIPTION
There was an issue where Option buttons would not toggle each other
on and off because the Select action was going through the
SpatialTarget and an Option group needs the Spatial Dispatcher to
dispatch the Select action so it knows which other buttons to dispatch
the Deselect action to.

The SpatialButton.OptionButton prefab now uses the
SpatialButtonConfigurator Select action as this goes through the
correct dispatcher when dealing with button groups.