### PR TITLE
fix(package.json): reduce textmeshpro version for older Unity vrsions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "io.extendreality.tilia.indicators.spatialtargets.unity": "1.5.10",
-        "com.unity.textmeshpro": "3.0.4"
+        "com.unity.textmeshpro": "1.3.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
TextMeshPro is only supported up to v1.3.0 on older versions of Unity
so this should be the base installed version and should be left to be
manually updated in newer versions of unity.