### PR TITLE
fix(SpatialButtonFacade): make ObjectReference setter private

### DIFF
--- a/Runtime/SharedResources/Scripts/SpatialButtonFacade.cs
+++ b/Runtime/SharedResources/Scripts/SpatialButtonFacade.cs
@@ -118,7 +118,7 @@
                 {
                     return container;
                 }
-                set
+                protected set
                 {
                     container = value;
                 }


### PR DESCRIPTION
The ObjectReference `Container` property should have a protected setter
as it is only for use within the Unity Editor and should not be able to
be set via code.