### PR TITLE
feat(Editor): add custom buttons for facade

### DIFF
--- a/Editor/SpatialButtonFacadeEditor.cs
+++ b/Editor/SpatialButtonFacadeEditor.cs
@@ -1,0 +1,82 @@
+﻿namespace Tilia.Interactions.SpatialButtons
+{
+    using System;
+    using UnityEditor;
+    using UnityEngine;
+    using Zinnia.Utility;
+
+    [CustomEditor(typeof(SpatialButtonFacade), true)]
+    public class SpatialButtonFacadeEditor : ZinniaInspector
+    {
+        private const string copyDataButtonText = "Copy Text and Size";
+        private const string copyDataButtonTooltip = "Copies the text and font size from the Enabled Inactive state to all other states.";
+        private const string previewButtonText = "Preview Style";
+        private SpatialButtonFacade facade;
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            try
+            {
+                GUILayout.BeginHorizontal("GroupBox");
+                GUILayout.FlexibleSpace();
+                if (GUILayout.Button(new GUIContent(copyDataButtonText, copyDataButtonTooltip)))
+                {
+                    CopyTextAndSize();
+                }
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal("GroupBox");
+                GUILayout.FlexibleSpace();
+                if (GUILayout.Button(previewButtonText))
+                {
+                    PreviewStyle();
+                }
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+            }
+            catch (Exception exception)
+            {
+                if (exception.GetType() != typeof(ExitGUIException) && exception.GetType() != typeof(ArgumentException))
+                {
+                    Debug.LogError(exception);
+                }
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            facade = (SpatialButtonFacade)serializedObject.targetObject;
+        }
+
+        protected virtual void CopyTextAndSize()
+        {
+            serializedObject.Update();
+            string textToCopy = facade.EnabledInactive.ButtonText;
+            float fontSizeToCopy = facade.EnabledInactive.FontSize;
+
+            CopyTextAndSize("enabledActive", textToCopy, fontSizeToCopy);
+            CopyTextAndSize("enabledHover", textToCopy, fontSizeToCopy);
+            CopyTextAndSize("disabledInactive", textToCopy, fontSizeToCopy);
+            CopyTextAndSize("disabledHover", textToCopy, fontSizeToCopy);
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        protected virtual void CopyTextAndSize(string type, string textToCopy, float fontSizeToCopy)
+        {
+            SerializedProperty text = serializedObject.FindProperty(type + ".buttonText");
+            text.stringValue = textToCopy;
+
+            SerializedProperty fontSize = serializedObject.FindProperty(type + ".fontSize");
+            fontSize.floatValue = fontSizeToCopy;
+        }
+
+        protected virtual void PreviewStyle()
+        {
+            facade.Configuration.ConfigureButton();
+        }
+    }
+}

--- a/Editor/SpatialButtonFacadeEditor.cs.meta
+++ b/Editor/SpatialButtonFacadeEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ded7fef809ce75847ba2d5106a003f3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tilia.Interactions.SpatialButtons.Editor.asmdef
+++ b/Editor/Tilia.Interactions.SpatialButtons.Editor.asmdef
@@ -1,8 +1,10 @@
 {
     "name": "Tilia.Interactions.SpatialButtons.Editor",
     "references": [
-        "Zinnia.Editor"
+        "Zinnia.Editor",
+        "Tilia.Interactions.SpatialButtons.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -11,7 +13,5 @@
     "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Runtime/SharedResources/Scripts/SpatialButtonConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SpatialButtonConfigurator.cs
@@ -391,13 +391,34 @@
                 return;
             }
 
+            Mesh meshCopy = null;
+            int verticesLength = 0;
+
+            if (Application.isPlaying)
+            {
+                verticesLength = meshFilter.mesh.vertices.Length;
+            }
+            else
+            {
+                meshCopy = Instantiate(meshFilter.sharedMesh);
+                verticesLength = meshCopy.vertices.Length;
+            }
+
             List<Color> colors = new List<Color>();
-            for (int colorIndex = 0; colorIndex < meshFilter.mesh.vertices.Length; colorIndex++)
+            for (int colorIndex = 0; colorIndex < verticesLength; colorIndex++)
             {
                 colors.Add(style.MeshColor);
             }
 
-            meshFilter.mesh.SetColors(colors);
+            if (Application.isPlaying)
+            {
+                meshFilter.mesh.SetColors(colors);
+            }
+            else
+            {
+                meshCopy.SetColors(colors);
+                meshFilter.mesh = meshCopy;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
A new custom inspector editor has been added for the Spatial Button
Facade that renders a `Copy Text and Size` button that will copy
the text and font size from the enabled inactive style to all the other
states to make it easier to update.

There is also a `Preview Style` button that will apply the styles in
the editor so it is easy to see what the button looks like without
needing to run the scene in play mode.