### PR TITLE
fix(Materials): swap button shader to mobile friendly version

### DIFF
--- a/Editor/SpatialButtonFacadeEditor.cs
+++ b/Editor/SpatialButtonFacadeEditor.cs
@@ -19,7 +19,9 @@
 
             try
             {
-                GUILayout.BeginHorizontal("GroupBox");
+                GUILayout.BeginVertical("GroupBox");
+
+                GUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
                 if (GUILayout.Button(new GUIContent(copyDataButtonText, copyDataButtonTooltip)))
                 {
@@ -28,7 +30,9 @@
                 GUILayout.FlexibleSpace();
                 GUILayout.EndHorizontal();
 
-                GUILayout.BeginHorizontal("GroupBox");
+                EditorHelper.DrawHorizontalLine();
+
+                GUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
                 if (GUILayout.Button(previewButtonText))
                 {
@@ -36,6 +40,8 @@
                 }
                 GUILayout.FlexibleSpace();
                 GUILayout.EndHorizontal();
+
+                GUILayout.EndVertical();
             }
             catch (Exception exception)
             {

--- a/Runtime/Prefabs/Interactions.SpatialButton.ClickButton.prefab
+++ b/Runtime/Prefabs/Interactions.SpatialButton.ClickButton.prefab
@@ -7,10 +7,41 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1972814824867083557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2180264, guid: 2e498d1c8094910479dc3e1b768306a4, type: 2}
+    - target: {fileID: 2523722850827099774, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 2523722850827099774, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: deselectSelfDelay
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: actionsOnHover
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: actionsOnActivate
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 3991973942380455354, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
       propertyPath: m_Name
-      value: Interactions.SpatialButton.Click
+      value: Interactions.SpatialButton.ClickButton
       objectReference: {fileID: 0}
     - target: {fileID: 3991973942380455356, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
@@ -67,20 +98,32 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 4088187645122458557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: deselectSelfDelay
-      value: 0.1
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 5299522958527608246, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: actionsOnHover
-      value: 0
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 5299522958527608246, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 6848573179124016618, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: actionsOnActivate
-      value: 2
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 6848573179124016618, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
@@ -92,10 +135,27 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4088187645122458557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: m_Mesh
+      propertyPath: m_fontAsset
       value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 2180264, guid: 2e498d1c8094910479dc3e1b768306a4, type: 2}
+    - target: {fileID: 7576476292929350410, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 7576476292929350410, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6c5e61ad8d2b39f4da6fc035d795d871, type: 3}

--- a/Runtime/Prefabs/Interactions.SpatialButton.OptionButton.prefab
+++ b/Runtime/Prefabs/Interactions.SpatialButton.OptionButton.prefab
@@ -7,6 +7,42 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1712782886781501726, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: Extracted.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1639191951141537450}
+    - target: {fileID: 1712782886781501726, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: Extracted.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Select
+      objectReference: {fileID: 0}
+    - target: {fileID: 1972814824867083557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2180264, guid: 2e498d1c8094910479dc3e1b768306a4, type: 2}
+    - target: {fileID: 2523722850827099774, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 2523722850827099774, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: actionsOnHover
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: actionsOnActivate
+      value: 21
+      objectReference: {fileID: 0}
     - target: {fileID: 3991973942380455354, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
       propertyPath: m_Name
@@ -67,15 +103,32 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 4088187645122458557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: actionsOnHover
-      value: 0
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 5299522958527608246, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: actionsOnActivate
-      value: 21
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 5299522958527608246, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6848573179124016618, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 6848573179124016618, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
@@ -87,20 +140,27 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1712782886781501726, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: Extracted.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      propertyPath: m_fontAsset
       value: 
-      objectReference: {fileID: 1639191951141537450}
-    - target: {fileID: 1712782886781501726, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: Extracted.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: Select
-      objectReference: {fileID: 0}
-    - target: {fileID: 4088187645122458557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
-        type: 3}
-      propertyPath: m_Mesh
+      propertyPath: m_sharedMaterial
       value: 
+      objectReference: {fileID: 2180264, guid: 2e498d1c8094910479dc3e1b768306a4, type: 2}
+    - target: {fileID: 7576476292929350410, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 7576476292929350410, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6c5e61ad8d2b39f4da6fc035d795d871, type: 3}

--- a/Runtime/Prefabs/Interactions.SpatialButton.ToggleButton.prefab
+++ b/Runtime/Prefabs/Interactions.SpatialButton.ToggleButton.prefab
@@ -7,10 +7,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1972814824867083557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2180264, guid: 2e498d1c8094910479dc3e1b768306a4, type: 2}
+    - target: {fileID: 2523722850827099774, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 2523722850827099774, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: actionsOnHover
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: actionsOnActivate
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3991973942380455354, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
       propertyPath: m_Name
-      value: Interactions.SpatialButton.Toggle
+      value: Interactions.SpatialButton.ToggleButton
       objectReference: {fileID: 0}
     - target: {fileID: 3991973942380455356, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
@@ -67,15 +93,32 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 4088187645122458557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: actionsOnHover
-      value: 0
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 3937061634882221739, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 5299522958527608246, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: actionsOnActivate
-      value: 0
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 5299522958527608246, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6848573179124016618, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 6848573179124016618, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
@@ -87,10 +130,27 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4088187645122458557, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+    - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
         type: 3}
-      propertyPath: m_Mesh
+      propertyPath: m_fontAsset
       value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 7540004184583538857, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 2180264, guid: 2e498d1c8094910479dc3e1b768306a4, type: 2}
+    - target: {fileID: 7576476292929350410, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 2e498d1c8094910479dc3e1b768306a4,
+        type: 2}
+    - target: {fileID: 7576476292929350410, guid: 6c5e61ad8d2b39f4da6fc035d795d871,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6c5e61ad8d2b39f4da6fc035d795d871, type: 3}

--- a/Runtime/SharedResources/Materials/ButtonMesh.mat
+++ b/Runtime/SharedResources/Materials/ButtonMesh.mat
@@ -8,15 +8,14 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ButtonMesh
-  m_Shader: {fileID: 210, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_Shader: {fileID: 4800000, guid: 12879b2ff8516c64684131071bf14814, type: 3}
+  m_ShaderKeywords: _EMISSION
   m_LightmapFlags: 0
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
-  disabledShaderPasses:
-  - ALWAYS
+  disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -33,6 +32,10 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -62,6 +65,8 @@ Material:
     - _CameraFadingEnabled: 0
     - _CameraFarFadeDistance: 2
     - _CameraNearFadeDistance: 1
+    - _ColorMask: 15
+    - _ColorMode: 0
     - _Cull: 2
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
@@ -86,10 +91,20 @@ Material:
     - _SoftParticlesNearFadeDistance: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Strength: 0.2
     - _UVSec: 0
+    - _UseUIAlphaClip: 0
     - _ZWrite: 1
     m_Colors:
     - _CameraFadeParams: {r: 0, g: Infinity, b: 0, a: 0}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _ColorAddSubDiff: {r: 0, g: 0, b: 0, a: 0}
+    - _EmisColor: {r: 0.2, g: 0.2, b: 0.2, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SoftParticleFadeParams: {r: 0, g: 0, b: 0, a: 0}
+    - _Specular: {r: 0, g: 0, b: 0, a: 0}

--- a/Runtime/SharedResources/Scripts/SpatialButtonConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SpatialButtonConfigurator.cs
@@ -1,7 +1,6 @@
 ﻿namespace Tilia.Interactions.SpatialButtons
 {
     using System;
-    using System.Collections.Generic;
     using Tilia.Indicators.SpatialTargets;
     using TMPro;
     using UnityEngine;
@@ -374,7 +373,7 @@
                 return;
             }
 
-            ApplyMeshStyle(button.ButtonMeshFilter, style);
+            ApplyMeshStyle(button, style);
             ApplyTextStyle(button.Text, style);
             RescaleButton(button.TextRect);
         }
@@ -382,43 +381,18 @@
         /// <summary>
         /// Styles the mesh with the given style.
         /// </summary>
-        /// <param name="meshFilter">The mesh to style.</param>
+        /// <param name="button">The button to style.</param>
         /// <param name="style">The styles to apply.</param>
-        protected virtual void ApplyMeshStyle(MeshFilter meshFilter, SpatialButtonFacade.ButtonStyle style)
+        protected virtual void ApplyMeshStyle(ButtonElement button, SpatialButtonFacade.ButtonStyle style)
         {
-            if (meshFilter == null)
+            if (button.ButtonMeshRenderer == null)
             {
                 return;
             }
 
-            Mesh meshCopy = null;
-            int verticesLength = 0;
-
-            if (Application.isPlaying)
-            {
-                verticesLength = meshFilter.mesh.vertices.Length;
-            }
-            else
-            {
-                meshCopy = Instantiate(meshFilter.sharedMesh);
-                verticesLength = meshCopy.vertices.Length;
-            }
-
-            List<Color> colors = new List<Color>();
-            for (int colorIndex = 0; colorIndex < verticesLength; colorIndex++)
-            {
-                colors.Add(style.MeshColor);
-            }
-
-            if (Application.isPlaying)
-            {
-                meshFilter.mesh.SetColors(colors);
-            }
-            else
-            {
-                meshCopy.SetColors(colors);
-                meshFilter.mesh = meshCopy;
-            }
+            Material updateMaterial = new Material(button.ButtonMeshRenderer.sharedMaterial);
+            updateMaterial.color = style.MeshColor;
+            button.ButtonMeshRenderer.sharedMaterial = updateMaterial;
         }
 
         /// <summary>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
+        "io.extendreality.zinnia.unity": "2.5.0",
+        "io.extendreality.tilia.utilities.shaders.unity": "1.3.1",
         "io.extendreality.tilia.indicators.spatialtargets.unity": "2.0.16",
         "com.unity.textmeshpro": "1.4.1"
     },


### PR DESCRIPTION
The standard unity particle shaders do not behave well on mobile devices such as the oculus quest so the shader has been switched out on the SpatialButton material to the Tilia vertex unlit shader.

The style setting code has been updated now to just use a simple shared material color set as this seems to work for all shaders.