### PR TITLE
fix(Editor): disable custom inspector if ignore custom editor is set

### DIFF
--- a/Editor/SpatialButtonFacadeEditor.cs
+++ b/Editor/SpatialButtonFacadeEditor.cs
@@ -1,5 +1,7 @@
 ﻿namespace Tilia.Interactions.SpatialButtons
 {
+#if ZINNIA_IGNORE_CUSTOM_INSPECTOR_EDITOR
+#else
     using System;
     using UnityEditor;
     using UnityEngine;
@@ -85,4 +87,5 @@
             facade.Configuration.ConfigureButton();
         }
     }
+#endif
 }


### PR DESCRIPTION
If the ZINNIA_IGNORE_CUSTOM_INSPECTOR_EDITOR ifdef is set then the custom editor must also be disabled otherwise an error will occur.